### PR TITLE
Hack: replace grpc with twirp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.7"
 black = { version = ">=19.3b0", optional = true }
-grpclib = "^0.4.1"
+twirp = "^0.0.7"
 jinja2 = { version = ">=3.0.3", optional = true }
 python-dateutil = "^2.8"
 isort = {version = "^5.11.5", optional = true}

--- a/src/betterproto/__init__.py
+++ b/src/betterproto/__init__.py
@@ -43,7 +43,6 @@ from .casing import (
     safe_snake_case,
     snake_case,
 )
-from .grpc.grpclib_client import ServiceStub
 
 
 # Proto 3 data types

--- a/src/betterproto/_types.py
+++ b/src/betterproto/_types.py
@@ -5,10 +5,7 @@ from typing import (
 
 
 if TYPE_CHECKING:
-    from grpclib._typing import IProtoMessage
-
     from . import Message
 
 # Bound type variable to allow methods to return `self` of subclasses
 T = TypeVar("T", bound="Message")
-ST = TypeVar("ST", bound="IProtoMessage")

--- a/src/betterproto/grpc/grpclib_client.py
+++ b/src/betterproto/grpc/grpclib_client.py
@@ -19,10 +19,9 @@ import grpclib.const
 if TYPE_CHECKING:
     from grpclib.client import Channel
     from grpclib.metadata import Deadline
+    from grpclib._typing import IProtoMessage
 
     from .._types import (
-        ST,
-        IProtoMessage,
         Message,
         T,
     )

--- a/src/betterproto/plugin/compiler.py
+++ b/src/betterproto/plugin/compiler.py
@@ -43,7 +43,7 @@ def outputfile_compiler(output_file: OutputTemplate) -> str:
         lines_after_imports=2,
         quiet=True,
         force_grid_wrap=2,
-        known_third_party=["grpclib", "betterproto"],
+        known_third_party=["twirp", "betterproto"],
     )
     return black.format_str(
         src_contents=code,

--- a/src/betterproto/plugin/models.py
+++ b/src/betterproto/plugin/models.py
@@ -738,13 +738,6 @@ class ServiceMethodCompiler(ProtoContentBase):
 
         # add imports required for request arguments timeout, deadline and metadata
         self.output_file.typing_imports.add("Optional")
-        self.output_file.imports_type_checking_only.add("import grpclib.server")
-        self.output_file.imports_type_checking_only.add(
-            "from betterproto.grpc.grpclib_client import MetadataLike"
-        )
-        self.output_file.imports_type_checking_only.add(
-            "from grpclib.metadata import Deadline"
-        )
 
         super().__post_init__()  # check for unset fields
 

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -32,8 +32,12 @@ from pydantic import {% for i in output_file.pydantic_imports|sort %}{{ i }}{% i
 
 import betterproto
 {% if output_file.services %}
-from betterproto.grpc.grpclib_server import ServiceBase
-import grpclib
+import twirp
+from twirp.base import Endpoint
+from twirp.context import Context
+from twirp.client import TwirpClient
+from twirp.server import TwirpServer
+from twirp.exceptions import TwirpServerException
 {% endif %}
 
 {% for i in output_file.imports|sort %}
@@ -102,149 +106,61 @@ class {{ message.py_name }}(betterproto.Message):
     {%  endif %}
 
 {% endfor %}
+
 {% for service in output_file.services %}
-class {{ service.py_name }}Stub(betterproto.ServiceStub):
+class {{ service.py_name }}Client(TwirpClient):
     {% if service.comment %}
 {{ service.comment }}
-
-    {% elif not service.methods %}
-    pass
     {% endif %}
+
     {% for method in service.methods %}
-    async def {{ method.py_name }}(self
-        {%- if not method.client_streaming -%}
-            {%- if method.py_input_message -%}, {{ method.py_input_message_param }}: "{{ method.py_input_message_type }}"{%- endif -%}
-        {%- else -%}
-            {# Client streaming: need a request iterator instead #}
-            , {{ method.py_input_message_param }}_iterator: Union[AsyncIterable["{{ method.py_input_message_type }}"], Iterable["{{ method.py_input_message_type }}"]]
-        {%- endif -%}
-            ,
-            *
-            , timeout: Optional[float] = None
-            , deadline: Optional["Deadline"] = None
-            , metadata: Optional["MetadataLike"] = None
-            ) -> {% if method.server_streaming %}AsyncIterator["{{ method.py_output_message_type }}"]{% else %}"{{ method.py_output_message_type }}"{% endif %}:
-        {% if method.comment %}
-{{ method.comment }}
-
-        {% endif %}
-        {% if method.server_streaming %}
-            {% if method.client_streaming %}
-        async for response in self._stream_stream(
-            "{{ method.route }}",
-            {{ method.py_input_message_param }}_iterator,
-            {{ method.py_input_message_type }},
-            {{ method.py_output_message_type.strip('"') }},
-            timeout=timeout,
-            deadline=deadline,
-            metadata=metadata,
-        ):
-            yield response
-            {% else %}{# i.e. not client streaming #}
-        async for response in self._unary_stream(
-            "{{ method.route }}",
-            {{ method.py_input_message_param }},
-            {{ method.py_output_message_type.strip('"') }},
-            timeout=timeout,
-            deadline=deadline,
-            metadata=metadata,
-        ):
-            yield response
-
-            {% endif %}{# if client streaming #}
-        {% else %}{# i.e. not server streaming #}
-            {% if method.client_streaming %}
-        return await self._stream_unary(
-            "{{ method.route }}",
-            {{ method.py_input_message_param }}_iterator,
-            {{ method.py_input_message_type }},
-            {{ method.py_output_message_type.strip('"') }},
-            timeout=timeout,
-            deadline=deadline,
-            metadata=metadata,
+    def {{ method.proto_name }}(self, *args, ctx, request, server_path_prefix="/twirp", **kwargs):
+        return self._make_request(
+        url=f"{server_path_prefix}/{{ output_file.package }}.{{ service.proto_name }}/{{ method.proto_name }}",
+            ctx=ctx,
+            request=request,
+            response_obj={{ method.py_output_message_type }},
+            **kwargs,
         )
-            {% else %}{# i.e. not client streaming #}
-        return await self._unary_unary(
-            "{{ method.route }}",
-            {{ method.py_input_message_param }},
-            {{ method.py_output_message_type.strip('"') }},
-            timeout=timeout,
-            deadline=deadline,
-            metadata=metadata,
-        )
-            {% endif %}{# client streaming #}
-        {% endif %}
+    {% endfor %}
+{% endfor %}
+
+{% for service in output_file.services %}
+class {{ service.py_name }}Base:
+    {% for method in service.methods %}
+    def {{ method.py_name }}(
+        self,
+        context: twirp.context.Context,
+        request: "{{ method.py_input_message_type }}",
+        ) -> "{{ method.py_output_message_type }}":
+            raise twirp.exceptions.TwirpServerException(
+                code=twirp.errors.Errors.Unimplemented,
+                message=f"Not implemented"
+            )
 
     {% endfor %}
 {% endfor %}
 
 {% for service in output_file.services %}
-class {{ service.py_name }}Base(ServiceBase):
+class {{ service.py_name }}Server(TwirpServer):
     {% if service.comment %}
 {{ service.comment }}
-
     {% endif %}
 
-    {% for method in service.methods %}
-    async def {{ method.py_name }}(self
-        {%- if not method.client_streaming -%}
-            {%- if method.py_input_message -%}, {{ method.py_input_message_param }}: "{{ method.py_input_message_type }}"{%- endif -%}
-        {%- else -%}
-            {# Client streaming: need a request iterator instead #}
-            , {{ method.py_input_message_param }}_iterator: AsyncIterator["{{ method.py_input_message_type }}"]
-        {%- endif -%}
-            ) -> {% if method.server_streaming %}AsyncIterator["{{ method.py_output_message_type }}"]{% else %}"{{ method.py_output_message_type }}"{% endif %}:
-        {% if method.comment %}
-{{ method.comment }}
-
-        {% endif %}
-        raise grpclib.GRPCError(grpclib.const.Status.UNIMPLEMENTED)
-        {% if method.server_streaming %}
-        yield {{ method.py_output_message_type }}()
-        {% endif %}
-
-    {% endfor %}
-
-    {% for method in service.methods %}
-    async def __rpc_{{ method.py_name }}(self, stream: "grpclib.server.Stream[{{ method.py_input_message_type }}, {{ method.py_output_message_type }}]") -> None:
-        {% if not method.client_streaming %}
-        request = await stream.recv_message()
-        {% else %}
-        request = stream.__aiter__()
-        {% endif %}
-        {% if not method.server_streaming %}
-        response = await self.{{ method.py_name }}(request)
-        await stream.send_message(response)
-        {% else %}
-        await self._call_rpc_handler_server_stream(
-            self.{{ method.py_name }},
-            stream,
-            request,
-        )
-        {% endif %}
-
-    {% endfor %}
-
-    def __mapping__(self) -> Dict[str, grpclib.const.Handler]:
-        return {
-        {% for method in service.methods %}
-        "{{ method.route }}": grpclib.const.Handler(
-            self.__rpc_{{ method.py_name }},
-            {% if not method.client_streaming and not method.server_streaming %}
-            grpclib.const.Cardinality.UNARY_UNARY,
-            {% elif not method.client_streaming and method.server_streaming %}
-            grpclib.const.Cardinality.UNARY_STREAM,
-            {% elif method.client_streaming and not method.server_streaming %}
-            grpclib.const.Cardinality.STREAM_UNARY,
-            {% else %}
-            grpclib.const.Cardinality.STREAM_STREAM,
-            {% endif %}
-            {{ method.py_input_message_type }},
-            {{ method.py_output_message_type }},
-        ),
-        {% endfor %}
+    def __init__(self, *args, service, server_path_prefix="/twirp"):
+        super().__init__(service=service)
+        self._prefix = f"{server_path_prefix}/{{ output_file.package }}.{{ service.proto_name }}"
+        self._endpoints = {
+            {% for method in service.methods %}
+            "{{ method.proto_name }}": Endpoint(
+                service_name="{{ service.proto_name }}",
+                name="{{ method.proto_name }}",
+                function=getattr(service, "{{ method.py_name }}"),
+                input={{ method.py_input_message_type }},
+                output={{ method.py_output_message_type }},
+            ),
+            {% endfor %}
         }
-
 {% endfor %}
 
 {% if output_file.pydantic_dataclasses %}

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -31,13 +31,15 @@ from pydantic import {% for i in output_file.pydantic_imports|sort %}{{ i }}{% i
 {% endif %}
 
 import betterproto
+
 {% if output_file.services %}
-import twirp
+import twirp.errors
+import twirp.exceptions
+import twirp.context
+
 from twirp.base import Endpoint
-from twirp.context import Context
 from twirp.client import TwirpClient
 from twirp.server import TwirpServer
-from twirp.exceptions import TwirpServerException
 {% endif %}
 
 {% for i in output_file.imports|sort %}


### PR DESCRIPTION
Replaces the grpclib dependency in betterproto with Twirp. This codegens Twirp client and servers that obey the wire protocol spec (and also match the Twirp python lib's template)

If we really wanted to do this correctly, we could do any or all of the following:

* Write some tests :)
* Write our own implementation of the twirp's wire protocol - this would allow us to remove the google protobuf dependency, since betterproto doesn't depend on it either
* Instead of ripping out grpc, make it an option at compilation / pip install, so that we could submit this patch back upstream and not have to maintain a fork